### PR TITLE
Handle FxA login locally with a different API host

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -191,6 +191,17 @@ define('utils', ['jquery', 'l10n', 'underscore'], function($, l10n, _) {
         return a;
     }
 
+    function urlorigin(url) {
+        var a = urlparse(url);
+        var origin = a.protocol + '//' + a.hostname;
+        if ((a.protocol == 'http' && a.port == 80) ||
+            (a.protocol == 'https' && a.port == 443)) {
+            return origin;
+        } else {
+            return origin + ':' + a.port;
+        }
+    }
+
     return {
         '_pd': _pd,
         'baseurl': baseurl,
@@ -205,6 +216,7 @@ define('utils', ['jquery', 'l10n', 'underscore'], function($, l10n, _) {
         'querystring': querystring,
         'slugify': slugify,
         'urlencode': urlencode,
+        'urlorigin': urlorigin,
         'urlparams': urlparams,
         'urlparse': urlparse,
         'urlunparam': urlunparam,

--- a/views/fxa_authorize.js
+++ b/views/fxa_authorize.js
@@ -1,5 +1,5 @@
-define('views/fxa_authorize', ['capabilities', 'log', 'login', 'utils', 'z'],
-       function(capabilities, log, login, utils, z) {
+define('views/fxa_authorize', ['capabilities', 'log', 'login', 'settings', 'utils', 'z'],
+       function(capabilities, log, login, settings, utils, z) {
     'use strict';
     var console = log('view', 'fxa-login');
     return function(builder) {
@@ -13,11 +13,13 @@ define('views/fxa_authorize', ['capabilities', 'log', 'login', 'utils', 'z'],
                 isPopup = true;
             }
         } catch (e) {
-            isPopup = false;
+            isPopup = window.location.hostname == 'localhost';
         }
         if (isPopup) {
-            window.opener.postMessage({auth_code: auth_code},
-                                      window.location.origin);
+            var messageOrigin = window.location.hostname == 'localhost' ?
+                                utils.urlorigin(settings.api_url) :
+                                window.location.origin;
+            window.opener.postMessage({auth_code: auth_code}, messageOrigin);
             // This code will execute from a hosted origin, since the FxA login
             // process redirects there. Nevertheless, this might be a window
             // opened by the Marketplace packaged app. So, let's send this info
@@ -38,7 +40,7 @@ define('views/fxa_authorize', ['capabilities', 'log', 'login', 'utils', 'z'],
                 new MozActivity({name: 'marketplace-app', data: {
                     type: 'login',
                     auth_code: auth_code,
-                    state: state}})
+                    state: state}});
                 window.close();
             } else {
                 login.handle_fxa_login(auth_code, state);


### PR DESCRIPTION
This allows logging in to zamboni running at http://localhost:2600 and using fireplace at http://localhost:8675 to handle FxA auth.

I'm not sure this is the right thing to do. It will prevent you from following the email link locally unfortunately. It might be better for zamboni to self-host the `/fxa-authorize` file for local login. I will try that tomorrow.
