### PR TITLE
Refactor device_* methods (bug 1083592)

### DIFF
--- a/capabilities.js
+++ b/capabilities.js
@@ -40,22 +40,37 @@ define('capabilities', ['settings'], function(settings) {
         return (!(static_caps.nativeFxA() || static_caps.yulelogFxA()));
     };
 
-    static_caps.device_type = function() {
+    /* Returns device platform name without the form factor ('dev' API parameter). */
+    static_caps.device_platform = function() {
         if (static_caps.firefoxOS) {
             return 'firefoxos';
         } else if (static_caps.firefoxAndroid) {
-            if (static_caps.widescreen()) {  // TODO(buchets): Retire me
-                return 'android-tablet';
-            }
-            return 'android-mobile';
-        } else {
-            return 'desktop';
+            return 'android';
         }
+        return 'desktop';
     };
 
-    static_caps.device_platform = function() {
-        // Remove "-tablet" and "-mobile" from android types.
-        return static_caps.device_type().split('-')[0];
+    /* Returns device form factor alone, i.e. 'tablet' or 'mobile' ('device' API parameter).
+     * Only supported for Android currently. */
+    static_caps.device_formfactor = function() {
+        if (static_caps.firefoxAndroid) {
+            if (static_caps.widescreen()) {
+                return 'tablet';
+            }
+            return 'mobile';
+        }
+        return '';
+    };
+
+    /* Returns full device type information, e.g. 'android-mobile' or 'firefoxos' as exposed by the API. */
+    static_caps.device_type = function() {
+        var device_platform = static_caps.device_platform();
+        var device_formfactor = static_caps.device_formfactor();
+
+        if (device_platform && device_formfactor) {
+            return device_platform + '-' + device_formfactor;
+        }
+        return device_platform;
     };
 
     return static_caps;

--- a/tests/capabilities.js
+++ b/tests/capabilities.js
@@ -1,0 +1,115 @@
+(function() {
+var a = require('assert');
+var _ = require('underscore');
+var assert = a.assert;
+var eq_ = a.eq_;
+var eeq_ = a.eeq_;
+var feq_ = a.feq_;
+var mock = a.mock;
+
+test('capabilities device_platform', function(done, fail) {
+    mock(
+        'capabilities',
+        {
+            settings: {
+            }
+        },
+        function (capabilities) {
+            capabilities.firefoxOS = true;
+            eq_(capabilities.device_platform(), 'firefoxos');
+
+            capabilities.firefoxOS = false;
+            capabilities.firefoxAndroid = true;
+            eq_(capabilities.device_platform(), 'android');
+
+            capabilities.firefoxAndroid = false;
+            eq_(capabilities.device_platform(), 'desktop');
+            done();
+        },
+        fail
+    );
+});
+
+test('capabilities device_formfactor', function(done, fail) {
+    mock(
+        'capabilities',
+        {
+            settings: {
+            }
+        },
+        function (capabilities) {
+            capabilities.firefoxOS = true;
+            capabilities.widescreen = function() { return false; };
+            eq_(capabilities.device_formfactor(), '');
+
+            capabilities.firefoxOS = true;
+            // Firefox OS "tablet" size is not currently supported/differenciated from mobile.
+            capabilities.widescreen = function() { return true; };
+            eq_(capabilities.device_formfactor(), '');
+
+            capabilities.firefoxOS = false;
+            capabilities.firefoxAndroid = true;
+            capabilities.widescreen = function() { return false; };
+            eq_(capabilities.device_formfactor(), 'mobile');
+
+            capabilities.firefoxOS = false;
+            capabilities.firefoxAndroid = true;
+            capabilities.widescreen = function() { return true; };
+            eq_(capabilities.device_formfactor(), 'tablet');
+
+            capabilities.firefoxOS = false;
+            capabilities.firefoxAndroid = false;
+            capabilities.widescreen = function() { return false; };
+            eq_(capabilities.device_formfactor(), '');
+
+            capabilities.firefoxOS = false;
+            capabilities.firefoxAndroid = false;
+            capabilities.widescreen = function() { return true; };
+            eq_(capabilities.device_formfactor(), '');
+            done();
+        },
+        fail
+    );
+});
+
+test('capabilities device_type', function(done, fail) {
+    mock(
+        'capabilities',
+        {
+            settings: {}
+        },
+        function (capabilities) {
+            capabilities.firefoxOS = true;
+            capabilities.widescreen = function() { return false; };
+            eq_(capabilities.device_type(), 'firefoxos');
+
+            // Firefox OS "tablet" size is not currently supported/differenciated from mobile.
+            capabilities.widescreen = function() { return true; };
+            eq_(capabilities.device_type(), 'firefoxos');
+
+            capabilities.firefoxOS = false;
+            capabilities.firefoxAndroid = true;
+            capabilities.widescreen = function() { return false; };
+            eq_(capabilities.device_type(), 'android-mobile');
+
+            capabilities.firefoxOS = false;
+            capabilities.firefoxAndroid = true;
+            capabilities.widescreen = function() { return true; };
+            eq_(capabilities.device_type(), 'android-tablet');
+
+            capabilities.firefoxOS = false;
+            capabilities.firefoxAndroid = false;
+            capabilities.widescreen = function() { return false; };
+            eq_(capabilities.device_type(), 'desktop');
+
+            capabilities.firefoxOS = false;
+            capabilities.firefoxAndroid = false;
+            capabilities.widescreen = function() { return true; };
+            eq_(capabilities.device_type(), 'desktop');
+            done();
+        },
+        fail
+    );
+});
+
+})();

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -59,6 +59,7 @@
 </style>
 
 <script type="text/javascript" src="/media/js/lib/marketplace-core-modules/tests/cache.js"></script>
+<script type="text/javascript" src="/media/js/lib/marketplace-core-modules/tests/capabilities.js"></script>
 <script type="text/javascript" src="/media/js/lib/marketplace-core-modules/tests/l10n.js"></script>
 <script type="text/javascript" src="/media/js/lib/marketplace-core-modules/tests/navigation.js"></script>
 <script type="text/javascript" src="/media/js/lib/marketplace-core-modules/tests/models.js"></script>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1083592

This should be fully backwards-compatible, adding tests and a new 'device_formfactor' method. Will be used to remove duplicate code in fireplace's compatibility_filtering.js.