### PR TITLE
Allow login window re-use for payments (1122792, 1122790)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "author": "Mozilla",
   "name": "marketplace-core-modules",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "ignore": [
     "bower.json",
     "LICENSE",

--- a/utils.js
+++ b/utils.js
@@ -191,6 +191,24 @@ define('utils', ['jquery', 'l10n', 'underscore'], function($, l10n, _) {
         return a;
     }
 
+    function getCenteredCoordinates(width, height) {
+        var x = window.screenX + Math.max(0, Math.floor((window.innerWidth - width) / 2));
+        var y = window.screenY + Math.max(0, Math.floor((window.innerHeight - height) / 2));
+        return [x, y];
+    }
+
+    function openWindow(opts) {
+        opts = opts || {};
+        var url = opts.url || '';
+        var title = opts.title || 'fxa';
+        var w = opts.width || 320;
+        var h = opts.height || 600;
+        var centerCoords = getCenteredCoordinates(w, h);
+        return window.open(url, title,
+            'scrollbars=yes,width=' + w + ',height=' + h +
+            ',left=' + centerCoords[0] + ',top=' + centerCoords[1]);
+    }
+
     return {
         '_pd': _pd,
         'baseurl': baseurl,
@@ -202,6 +220,7 @@ define('utils', ['jquery', 'l10n', 'underscore'], function($, l10n, _) {
         'fieldFocused': fieldFocused,
         'getVars': getVars,
         'initCharCount': initCharCount,
+        'openWindow': openWindow,
         'querystring': querystring,
         'slugify': slugify,
         'urlencode': urlencode,

--- a/views/fxa_authorize.js
+++ b/views/fxa_authorize.js
@@ -25,9 +25,10 @@ define('views/fxa_authorize', ['capabilities', 'log', 'login', 'utils', 'z'],
             var packaged_origin = 'app://packaged.' + window.location.host;
             console.log('Sending OAuth code to parent window ' +
                         packaged_origin);
+            // Don't remove the splash screen for this view.
+            z.context.hide_splash = false;
+            // The opener will take responsibility of closing the window.
             window.opener.postMessage({auth_code: auth_code}, packaged_origin);
-
-            window.close();
         } else {
             // No popup, login was likely initiated via email.
             var state = utils.getVars().state;
@@ -38,7 +39,7 @@ define('views/fxa_authorize', ['capabilities', 'log', 'login', 'utils', 'z'],
                 new MozActivity({name: 'marketplace-app', data: {
                     type: 'login',
                     auth_code: auth_code,
-                    state: state}})
+                    state: state}});
                 window.close();
             } else {
                 login.handle_fxa_login(auth_code, state);


### PR DESCRIPTION
* Popup creation moved out to util.
* If `login.login()` is passed a window it uses it.
* Uses a feature added in the fireplace PR linked below to keep the splash screen showing for fxa_authorize so that whilst the window is open prior to launching payments or prior to closing it shows the splash screen.

See also: https://github.com/mozilla/fireplace/pull/924