### PR TITLE
Show status of skipped unittests

### DIFF
--- a/tests/tests.html
+++ b/tests/tests.html
@@ -6,11 +6,13 @@
       <th>Started</th>
       <th class="passed">Passed</th>
       <th class="failed">Failed</th>
+      <th class="skipped">Skipped</th>
     </tr>
     <tr>
       <td id="c_started">0</td>
       <td class="passed" id="c_passed">0</td>
       <td class="failed" id="c_failed">0</td>
+      <td class="skipped" id="c_skipped">0</td>
     </tr>
   </table>
   <ol class="tests"></ol>

--- a/views/tests.js
+++ b/views/tests.js
@@ -3,6 +3,7 @@ define('views/tests', ['assert', 'requests'], function(assert, requests) {
         var started = 0;
         var passed = 0;
         var failed = 0;
+        var skipped = 0;
 
         function is_done() {
             var ndone = passed + failed;
@@ -45,6 +46,18 @@ define('views/tests', ['assert', 'requests'], function(assert, requests) {
                 }
             }, 0);
             $('#c_started').text(started);
+        };
+
+        window.xtest = function(name) {
+            skipped++;
+            $('#c_skipped').text(skipped);
+            console.log('skipping test ' + name);
+            setTimeout(function() {
+                var infobox = $('<li><span style="background-color: gold">Skipped</span> <b>' + name + '</b></li>');
+                infobox.attr('status', 'skip');
+                infobox.attr('name', name);
+                $('ol.tests').append(infobox);
+            }, 0);
         };
 
         builder.start('tests.html');


### PR DESCRIPTION
I realised that `xtest` doesn't skip tests it just errors out and doesn't mention anything. I made it actually skip tests and show the output so we know we still have tests to fix.

![screenshot 2015-01-21 15 42 45](https://cloud.githubusercontent.com/assets/211578/5845743/39534158-a184-11e4-8683-4be110e4d197.png)
