### PR TITLE
Support native FxA on 2.0 (bug 1042886)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "author": "Mozilla",
   "name": "marketplace-core-modules",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "ignore": [
     "bower.json",
     "LICENSE",

--- a/capabilities.js
+++ b/capabilities.js
@@ -65,13 +65,13 @@ define('capabilities', ['settings'], function(settings) {
 
     static_caps.nativeFxA = function() {
         return (static_caps.firefoxOS && window.location.protocol === 'app:' &&
-                navigator.userAgent.match(/rv:(\d{2})/)[1] >= 34);
+                navigator.userAgent.match(/rv:(\d{2})/)[1] >= 32);
 
     };
     static_caps.yulelogFxA = function() {
         return (static_caps.firefoxOS && window.top !== window.self &&
                 settings.switches.indexOf('native-firefox-accounts') !== -1 &&
-                navigator.userAgent.match(/rv:(\d{2})/)[1] >= 34);
+                navigator.userAgent.match(/rv:(\d{2})/)[1] >= 32);
     };
     static_caps.fallbackFxA = function() {
         return (!(static_caps.nativeFxA() || static_caps.yulelogFxA()));


### PR DESCRIPTION
Turns out native FxA support for privileged apps landed in 2.0 after all.