### PR TITLE
v1.8.0 fix and refactor scroll states using events (bug 986625)

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -20,7 +20,10 @@ define('builder',
     }
 
     function render(template, context, env) {
-        return (env || nunjucks.env).render(template, context || {});
+        z.page.trigger('builder--pre-render');
+        var result = (env || nunjucks.env).render(template, context || {});
+        z.page.trigger('builder--post-render');
+        return result;
     }
 
     var error_template = render(settings.fragment_error_template);

--- a/navigation.js
+++ b/navigation.js
@@ -1,47 +1,31 @@
 define('navigation',
-    ['capabilities', 'l10n', 'log', 'notification', 'settings', 'underscore', 'utils', 'views', 'z'],
-    function(capabilities, l10n, log, notification, settings, _, utils, views, z) {
+    ['capabilities', 'l10n', 'log', 'notification', 'scroll_state', 'settings',
+     'underscore', 'utils', 'views', 'z'],
+    function(capabilities, l10n, log, notification, scroll_state, settings,
+             _, utils, views, z) {
     'use strict';
-
-    var console = log('nav');
-
     var gettext = l10n.gettext;
-    var stack = [
+    var logger = log('navigation');
+
+    var stack = [  // Internal object.
         {path: '/', type: 'root'}
     ];
     var initialized = false;
-    var scrollTimer;
 
-    function extract_nav_url(url) {
-        // This function returns the URL that we should use for navigation.
-        // It filters and orders the parameters to make sure that they pass
-        // equality tests down the road.
 
-        // If there's no URL params, return the original URL.
-        if (url.indexOf('?') < 0) {
-            return url;
+    function navigate(href, isPopping, state) {
+        /* Start navigation.
+           href -- URL to navigate to
+           isPopping -- whether going back/forward in the browser w/ pushState
+           state -- the new state we are navigating to
+        */
+        if (!state) {
+            return;
         }
 
-        // We can't use urlparams() because that only extends, not replaces.
-        var used_params = _.pick(utils.querystring(url), settings.param_whitelist);
-        var queryParams = utils.urlencode(used_params);
-        return utils.baseurl(url) + (queryParams.length ? '?' + queryParams : '');
-    }
-
-    function canNavigate() {
-        if (!navigator.onLine && !capabilities.phantom) {
-            notification.notification({message: gettext('No internet connection')});
-            return !!settings.offline_capable;
-        }
-        return true;
-    }
-
-    function navigate(href, popped, state) {
-        if (!state) {return;}
-
-        console.log('Navigation started: ', href);
         var view = views.match(href);
         if (view === null) {
+            logger.warn('Unable to resolve route to a view');
             return;
         }
 
@@ -50,38 +34,22 @@ define('navigation',
             return;
         }
 
+        logger.log('Navigation started: ', href);
+
+        if (isPopping) {
+            z.page.trigger('navigation--pop-state', [state]);
+        }
+
         if (initialized) {
             // Call navigating before the view build function so that modules
             // the view depend on can react in time.
-            z.win.trigger('navigating', [popped]);
+            z.win.trigger('navigating', [isPopping]);
         }
+
         views.build(view[0], view[1], state.params);
         initialized = true;
         state.type = z.context.type;
         state.title = z.context.title;
-
-        var top = 0;
-        if ((state.preserveScroll || popped) && state.scrollTop) {
-            if (state.docHeight) {
-                // Preserve document min-height for scroll restoration.
-                z.body.css('min-height', state.docHeight);
-                z.page.one('loaded', function() {
-                    // Remove specified min-height.
-                    z.body.css('min-height', '');
-                });
-            }
-            top = state.scrollTop;
-        }
-
-        // Introduce small delay to ensure content
-        // is ready to scroll. (Bug 976466)
-        if (scrollTimer) {
-            window.clearTimeout(scrollTimer);
-        }
-        scrollTimer = window.setTimeout(function() {
-            console.log('Setting scroll to', top);
-            window.scrollTo(0, top);
-        }, 250);
 
         // Clean the path's parameters.
         // /foo/bar?foo=bar&q=blah -> /foo/bar?q=blah
@@ -91,7 +59,7 @@ define('navigation',
         for (var i = 0; i < stack.length; i++) {
             if (stack[i].path === state.path ||
                 (state.type === 'search' && stack[i].type === state.type)) {
-                console.log('Navigation loop truncated:', stack.slice(0, i));
+                logger.log('Navigation loop truncated:', stack.slice(0, i));
                 stack = stack.slice(i + 1);
                 break;
             }
@@ -109,12 +77,12 @@ define('navigation',
             stack = [state];
             $('#search-q').val(''); // Bug 790009
         } else {
-            // handle the back and forward buttons.
-            if (popped && stack[0].path === state.path) {
-                console.log('Shifting stack (used → or ← button)');
+            // Handle the back and forward buttons.
+            if (isPopping && stack[0].path === state.path) {
+                logger.log('Shifting stack (used → or ← button)');
                 stack.shift();
             } else {
-                console.log('Pushed state onto stack: ', state.path);
+                logger.log('Pushed state onto stack: ', state.path);
                 stack.unshift(state);
             }
 
@@ -126,68 +94,52 @@ define('navigation',
                     // The parent is in the stack and it's not immediately
                     // behind the current page in the stack.
                     stack.splice(1, parent - 1);
-                    console.log('Closing navigation loop to parent (1 to ' + (parent - 1) + ')');
+                    logger.log('Closing navigation loop to parent (1 to ' + (parent - 1) + ')');
                 } else if (parent === -1) {
                     // The parent isn't in the stack. Splice it in just below
                     // where the value we just pushed in is.
                     stack.splice(1, 0, {path: z.context.parent});
-                    console.log('Injecting parent into nav stack at 1');
+                    logger.log('Injecting parent into nav stack at 1');
                 }
-                console.log('New stack size: ' + stack.length);
+                logger.log('New stack size: ' + stack.length);
             }
         }
-
     }
 
-    function back() {
-        if (!canNavigate()) {
-            console.log('← aborted; canNavigate is falsey.');
-            return;
-        }
 
+    function back() {
         if (stack.length > 1) {
             stack.shift();
             history.replaceState(stack[0], false, stack[0].path);
             navigate(stack[0].path, true, stack[0]);
         } else {
-            console.warn('attempted to go ← at root!');
+            logger.warn('Attempted to go back from root!');
         }
     }
 
-    z.page.on('navigate divert', function(e, url, params, preserveScroll) {
-        console.log('Received ' + e.type + ' event:', url);
-        if (!url) {return;}
+    z.page.on('navigate divert', function(e, url, params) {
+        logger.log('Received ' + e.type + ' event:', url);
+        if (!url) {
+            return;
+        }
+        if (!stack.length) {
+            stack = [
+                {path: '/', type: 'root'}
+            ];
+        }
+
+        z.page.trigger('navigation--pre-navigate', [stack[0]]);
 
         var divert = e.type === 'divert';
         var newState = {
             params: params,
             path: url
         };
-        var scrollTop = window.pageYOffset;
         var state_method = history.pushState;
 
-        if (preserveScroll) {
-            newState.preserveScroll = preserveScroll;
-            newState.scrollTop = scrollTop;
-            newState.docHeight = z.doc.height();
-        }
-
-        if (!canNavigate()) {
-            console.log('Navigation aborted; canNavigate is falsey.');
-            return;
-        }
-
-        // Update scrollTop for current history state.
-        if (stack.length && scrollTop !== stack[0].scrollTop) {
-            stack[0].scrollTop = scrollTop;
-            console.log('Updating scrollTop with replaceState');
-            history.replaceState(stack[0], false, stack[0].path);
-        }
-
         if (!initialized || divert) {
-            // If we're redirecting or we've never loaded a page before,
-            // use replaceState instead of pushState.
-            console.log('Using replaceState due to ' +
+            // If redirect/haven't loaded page yet, replaceState > pushState.
+            logger.log('Using replaceState due to ' +
                         (initialized ? 'diversion' : 'fresh load'));
             state_method = history.replaceState;
         }
@@ -197,6 +149,37 @@ define('navigation',
         state_method.apply(history, [newState, false, url]);
         navigate(url, false, newState);
     });
+
+
+    z.body.on('click', 'a', function(e) {
+        var href = this.getAttribute('href');
+        var $elm = $(this);
+        if (e.metaKey || e.ctrlKey || e.button !== 0) {
+            return;
+        }
+        if (navigationFilter(this)) {
+            return;
+        }
+        // Don't use utils._pd. Check for above situations first.
+        e.preventDefault();
+        e.stopPropagation();
+        z.page.trigger('navigate', [href, $elm.data('params') || {path: href}]);
+    });
+
+
+    function extract_nav_url(url) {
+        // Returns URL for nav, filtering/ordering params to pass equal. tests.
+        if (url.indexOf('?') < 0) {
+            // If no URL params, return original URL.
+            return url;
+        }
+
+        // Can't use urlparams() because that extends not replaces.
+        var used_params = _.pick(utils.querystring(url), settings.param_whitelist);
+        var queryParams = utils.urlencode(used_params);
+        return utils.baseurl(url) + (queryParams.length ? '?' + queryParams : '');
+    }
+
 
     function navigationFilter(el) {
         var href = el.getAttribute('href') || el.getAttribute('action');
@@ -209,22 +192,6 @@ define('navigation',
                 el.getAttribute('rel') === 'external';
     }
 
-    z.body.on('click', 'a', function(e) {
-        var href = this.getAttribute('href');
-        var $elm = $(this);
-        var preserveScrollData = $elm.data('preserveScroll');
-        // Handle both data-preserve-scroll and data-preserve-scroll="true"
-        var preserveScroll = typeof preserveScrollData !== 'undefined' && preserveScrollData !== false;
-        if (e.metaKey || e.ctrlKey || e.button !== 0) {return;}
-        if (navigationFilter(this)) {return;}
-
-        // We don't use _pd because we don't want to prevent default for the
-        // above situations.
-        e.preventDefault();
-        e.stopPropagation();
-        z.page.trigger('navigate', [href, $elm.data('params') || {path: href}, preserveScroll]);
-
-    });
 
     z.win.on('popstate', function(e) {
         if (!initialized) {
@@ -234,20 +201,23 @@ define('navigation',
         var state = e.originalEvent.state;
         if (state) {
             if (state.closeModalName) {
-                console.log('popstate closing modal');
+                logger.log('popstate closing modal');
                 cleanupModal(state.closeModalName);
             } else {
-                console.log('popstate navigate');
+                logger.log('popstate navigate');
                 navigate(state.path, true, state);
             }
         }
-    }).on('submit', 'form', function() {
+    })
+
+    .on('submit', 'form', function() {
         console.error("Form submissions are not allowed.");
         return false;
     });
 
+
     function modal(name) {
-        console.log('Opening modal', name);
+        logger.log('Opening modal', name);
         stack[0].closeModalName = name;
         history.replaceState(stack[0], false, stack[0].path);
         history.pushState(null, name, '#' + name);
@@ -263,10 +233,10 @@ define('navigation',
 
     function closeModal(name) {
         if (stack[0].type === 'modal' && stack[0].name === name) {
-            console.log('Closing modal', name);
+            logger.log('Closing modal', name);
             history.back();
         } else {
-            console.log('Attempted to close modal', name, 'that was not open');
+            logger.log('Attempted to close modal', name, 'that was not open');
         }
     }
 
@@ -274,9 +244,10 @@ define('navigation',
         'back': back,
         'modal': modal,
         'closeModal': closeModal,
-        'stack': function() {return stack;},
+        'stack': function() {
+            return stack;
+        },
         'navigationFilter': navigationFilter,
         'extract_nav_url': extract_nav_url
     };
-
 });

--- a/scroll_state.js
+++ b/scroll_state.js
@@ -1,0 +1,53 @@
+/*
+    Handles scroll state alongside navigation.
+    Scroll state has a long history which can be seen at bug 986625.
+*/
+define('scroll_state',
+    ['log', 'z'],
+    function(log, z) {
+    var logger = log('scroll_state');
+
+    z.page.on('navigation--pre-navigate', function(e, state) {
+        // state -- current state before we shift to a new one onto stack.
+        logger.log('Navigating to new page, setting scroll to 0');
+
+        // Preserve scroll of current state before we reset the scroll to 0.
+        var scrollTop = window.pageYOffset;
+        if (scrollTop !== state.scrollTop) {
+            logger.log('Preserving scroll state', scrollTop);
+            state.scrollTop = scrollTop;
+            state.docHeight = z.doc.height();
+            history.replaceState(state, false, state.path);
+        }
+
+        // Now that scroll state is saved, set to 0.
+        // Setting scroll without waiting on an event or setTimeout can
+        // sometimes cause some race condition where the scroll is never set.
+        z.page.one('builder--post-render', function() {
+            setTimeout(function() {
+                window.scrollTo(0, 0);
+            });
+        });
+    });
+
+    z.page.on('navigation--pop-state', function(e, state) {
+        // If popping history state, check if we have a scrollTop saved.
+        // If so, then reset the scroll to the saved scrollTop.
+        if (!state.scrollTop) {
+            return;
+        }
+
+        logger.log('Popping and resetting scroll to', state.scrollTop);
+        z.page.one('loaded', function() {
+            if (state.docHeight) {
+                z.body.css('min-height', state.docHeight);
+                z.page.one('loaded', function() {
+                    z.body.css('min-height', '');
+                });
+            }
+            setTimeout(function() {
+                window.scrollTo(0, state.scrollTop);
+            });
+        });
+    });
+});


### PR DESCRIPTION
- add two events to builder: ```builder--pre-render```, ```builder-post-render```. These happen immediately before and Nunjucks rendering.
- add two events to navigation: ```navigation--pop-state``` (clicking back) and ```navigation-pre-navigate``` (clicking a link, before a new state is shifted)
- separate scroll state logic from navigation and have navigation require scroll_state
- some code clean up

Scroll logic:

- When navigating (clicking a link for ```navigation-pre-navigate```), save the state and then set the scroll to 0 on ```builder--post-render```.
- When popping (going back for ```navigation--pop-state```), set the scroll to the saved state on ```page.loaded```