### PR TITLE
Fix native FxA login on prod (bug 1133954)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "author": "Mozilla",
   "name": "marketplace-core-modules",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "ignore": [
     "bower.json",
     "LICENSE",

--- a/login.js
+++ b/login.js
@@ -11,6 +11,9 @@ define('login',
     var retainPopup;
     var pending_logins = [];
     var packaged_origin = "app://packaged." + window.location.host;
+    if (window.location.host === "marketplace.firefox.com") {
+        packaged_origin = "app://marketplace.firefox.com";
+    }
     function oncancel() {
         console.log('Login cancelled');
         z.page.trigger('login_cancel');


### PR DESCRIPTION
Problem is that prod's app url differs from the pattern used in all our other deployments.