### PR TITLE
Load settings and routes first (bug 1138690)

### DIFF
--- a/core/builder.js
+++ b/core/builder.js
@@ -27,7 +27,9 @@ define('core/builder',
         return result;
     }
 
-    var error_template = '<h1>error</h1>';  // render(settings.fragment_error_template);
+    function error_template() {
+        return render(settings.fragment_error_template);
+    }
 
     function parse_and_find(snippet, selector) {
         var dom = document.implementation.createHTMLDocument('');
@@ -155,7 +157,7 @@ define('core/builder',
                                 content = parse_and_find(content, extract).innerHTML;
                             } catch (e) {
                                 logger.error('Error extracting result from rendered response.');
-                                content = error_template;
+                                content = error_template();
                             }
                         }
                         return content;
@@ -246,7 +248,7 @@ define('core/builder',
                             }
                             context.ctx.response = response;
                             context.ctx.error = code;
-                            el.innerHTML = except ? except() : error_template;
+                            el.innerHTML = except ? except() : error_template();
                         }
                         trigger_fragment_load_failed({context: context,
                                                       signature: signature});
@@ -294,7 +296,7 @@ define('core/builder',
                         var fallback = signature.fallback;
                         if (fallback && fallback !== url) {
                             request = pool.get(fallback).done(done).fail(function() {
-                                done(error_template);
+                                done(error_template());
                             });
                         }
                     });

--- a/core/init.js
+++ b/core/init.js
@@ -22,6 +22,6 @@ define('core/init',
             return {lang: utils.lang()};
         });
 
-        require([settings.init_module], function() {});
+        require(['main'], function() {});
     });
 });

--- a/core/init.js
+++ b/core/init.js
@@ -1,5 +1,5 @@
 define('core/init',
-    ['settings_app', 'routes'],
+    ['routes', 'settings_app'],
     function() {
 
     require(['core/helpers', 'core/navigation', 'core/polyfill', 'core/router',

--- a/core/init.js
+++ b/core/init.js
@@ -1,21 +1,27 @@
 define('core/init',
-    ['core/helpers', 'core/navigation', 'core/polyfill', 'core/router',
-     'core/utils'],
-    function(helpers, navigation, polyfill, router,
-             utils) {
+    ['settings_app', 'routes'],
+    function() {
 
-    router.addRoutes([
-        {'pattern': '^/fxa-authorize$', 'view_name': 'core/fxa_authorize'},
-    ]);
+    require(['core/helpers', 'core/navigation', 'core/polyfill', 'core/router',
+             'core/settings', 'core/utils'],
+        function(helpers, navigation, polyfill, router,
+                 settings, utils) {
 
-    router.api.addRoutes({
-        'fxa-login': '/api/v2/account/fxa-login/',
-        'login': '/api/v2/account/login/',
-        'logout': '/api/v2/account/logout/',
-        'site-config': '/api/v2/services/config/site/?serializer=commonplace',
-    });
+        router.addRoutes([
+            {'pattern': '^/fxa-authorize$', 'view_name': 'core/fxa_authorize'},
+        ]);
 
-    router.api.addProcessor(function(endpoint) {
-        return {lang: utils.lang()};
+        router.api.addRoutes({
+            'fxa-login': '/api/v2/account/fxa-login/',
+            'login': '/api/v2/account/login/',
+            'logout': '/api/v2/account/logout/',
+            'site-config': '/api/v2/services/config/site/?serializer=commonplace',
+        });
+
+        router.api.addProcessor(function(endpoint) {
+            return {lang: utils.lang()};
+        });
+
+        require([settings.init_module], function() {});
     });
 });

--- a/core/storage.js
+++ b/core/storage.js
@@ -63,7 +63,7 @@ define('core/storage',
                     e.name == 'NS_ERROR_DOM_QUOTA_REACHED') {
                     console.log('LocalStorage full, clearing and reloading');
                     ls.clear();
-                    require('views').reload();
+                    require('core/views').reload();
                 }
             }
         }


### PR DESCRIPTION
Load settings and routes in core/init.js. Depends on https://github.com/mozilla/marketplace-gulp/pull/11 to require `core/init` instead of `main` in the built JS.