### PR TITLE
split l10n.js into global part and AMD part, fall back to en-US if no locale file (bug 985552/1044195)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "author": "Mozilla",
   "name": "marketplace-core-modules",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "ignore": [
     "bower.json",
     "LICENSE",

--- a/core/l10n.js
+++ b/core/l10n.js
@@ -1,137 +1,72 @@
-(function() {
+/*
+    Localization module.
 
-// This is a little misleading.  If you're using the Marketplace this is likely
-// overridden below with body_langs.  See bug 892741 for details.
-var languages = [
-    'bg', 'bn-BD', 'ca', 'cs', 'da', 'de', 'el', 'en-US', 'es', 'eu', 'fr',
-    'ga-IE', 'hr', 'hu', 'it', 'ja', 'ko', 'mk', 'nb-NO', 'nl', 'pa',
-    'pl', 'pt-BR', 'ro', 'ru', 'sk', 'sq', 'sr', 'sr-Latn', 'ta', 'tr',
-    'xh', 'zh-CN', 'zh-TW', 'zu', 'dbg'
-];
-// Resist the temptation to use .dataset, as it doesn't work with IE10.
-var body_langs = document.body.getAttribute('data-languages');
-if (body_langs) {
-    languages = JSON.parse(body_langs);
-}
+    Exposes gettext and ngettext functions that look up a string in the
+    window.navigator.l10n object to find the appropriate translation. The
+    window.navigator.l10n object is populated by l10n_init.js, which detects
+    the user's locale and injects a script tag with the locale .po file.
 
-var lang_expander = {
-    'en': 'en-US', 'ga': 'ga-IE',
-    'pt': 'pt-BR', 'sv': 'sv-SE',
-    'zh': 'zh-CN', 'sr': 'sr-Latn'
-};
+    l10n_init.js and this l10n.js module used to be one file which ended up
+    being requested twice. It has since been split.
+*/
+define('core/l10n', ['core/format'], function(format) {
+    var rtlList = ['ar', 'he', 'fa', 'ps', 'ur'];
 
-function get_locale(locale) {
-    if (languages.indexOf(locale) !== -1) {
-        return locale;
-    }
-    locale = locale.split('-')[0];
-    if (languages.indexOf(locale) !== -1) {
-        return locale;
-    }
-    if (locale in lang_expander) {
-        locale = lang_expander[locale];
-        if (languages.indexOf(locale) !== -1) {
-            return locale;
+    function get(str, args, context) {
+        context = context || navigator;
+        var out;
+        if (context.l10n && context.l10n.strings &&
+            str in context.l10n.strings) {
+            out = context.l10n.strings[str].body || str;
+        } else {
+            out = str;
         }
-    }
-    return 'en-US';
-}
-
-function get_locale_src(locale, document) {
-    if (!document) {
-        document = window.document;
-    }
-    // We need the CDN url, but only in a website context - if we are inside a
-    // packaged app, we don't want an unecessary network request. Fortunately,
-    // the packaged app's app.html shouldn't have data-media set on its <body>.
-    var media_url = document.body.getAttribute('data-media');
-    // If we have a build id, cool, we'll use that to do cachebusting. If we
-    // don't, then we're probably in a packaged app context again and don't
-    // need to care about that.
-    var build_id = document.body.getAttribute('data-build-id-js');
-    var repo = document.body.getAttribute('data-repo');
-    return [
-        media_url ? media_url : '/media/',
-        repo ? repo + '/' : '',
-        'locales/' + locale + '.js',
-        build_id ? '?b=' + build_id : ''
-    ].join('');
-}
-
-if (!window.define) {
-    var qs_lang = /[\?&]lang=([\w\-]+)/i.exec(window.location.search);
-    var locale = get_locale((qs_lang && qs_lang[1]) || navigator.language || navigator.userLanguage);
-    if (locale === 'en-US') {
-        // Pull the English locales in since feed editorial brand strings
-        // don't necessarily always match the gettext key. So don't return
-        // here.
-        window.navigator.l10n = {language: 'en-US'};
+        if (args) {
+            out = format.format(out, args);
+        }
+        return out;
     }
 
-    /* jshint ignore:start */
-    document.write('<script src="' + get_locale_src(locale) + '"></script>');
-    /* jshint ignore:end */
-
-} else {
-    define('core/l10n', ['core/format'], function(format) {
-        var rtlList = ['ar', 'he', 'fa', 'ps', 'ur'];
-
-        function get(str, args, context) {
-            context = context || navigator;
-            var out;
-            if (context.l10n && context.l10n.strings && str in context.l10n.strings) {
-                out = context.l10n.strings[str].body || str;
+    function nget(str, plural, args, context) {
+        context = context || navigator;
+        if (!args || !('n' in args)) {
+            throw new Error('`n` not passed to ngettext');
+        }
+        var out;
+        var n = args.n;
+        var strings;
+        var fallback = n === 1 ? str : plural;
+        if (context.l10n && context.l10n.strings &&
+            str in (strings = context.l10n.strings)) {
+            if (strings[str].plurals) {
+                // +true is 1 / +false is 0
+                var plid = +context.l10n.pluralize(n);
+                out = strings[str].plurals[plid] || fallback;
             } else {
-                out = str;
+                // Support languages like zh-TW which have no plural form.
+                out = strings[str].body || fallback;
             }
-            if (args) {
-                out = format.format(out, args);
-            }
-            return out;
+        } else {
+            out = fallback;
         }
-        function nget(str, plural, args, context) {
-            context = context || navigator;
-            if (!args || !('n' in args)) {
-                throw new Error('`n` not passed to ngettext');
-            }
-            var out;
-            var n = args.n;
-            var strings;
-            var fallback = n === 1 ? str : plural;
-            if (context.l10n && context.l10n.strings && str in (strings = context.l10n.strings)) {
-                if (strings[str].plurals) {
-                    // +true is 1 / +false is 0
-                    var plid = +context.l10n.pluralize(n);
-                    out = strings[str].plurals[plid] || fallback;
-                } else {
-                    // Support for languages like zh-TW where there is no plural form.
-                    out = strings[str].body || fallback;
-                }
-            } else {
-                out = fallback;
-            }
-            return format.format(out, args);
-        }
+        return format.format(out, args);
+    }
 
-        window.gettext = get;
-        window.ngettext = nget;
+    window.gettext = get;
+    window.ngettext = nget;
 
-        return {
-            gettext: get,
-            ngettext: nget,
-            getDirection: function(context) {
-                var language = context ? context.language : window.navigator.l10n.language;
-                if (language.indexOf('-') > -1) {
-                    language = language.split('-')[0];
-                }
-                // http://www.w3.org/International/questions/qa-scripts
-                // Arabic, Hebrew, Farsi, Pashto, Urdu
-                return rtlList.indexOf(language) >= 0 ? 'rtl' : 'ltr';
-            },
-            getLocaleSrc: get_locale_src,
-            getLocale: get_locale,
-            languages: languages
-        };
-    });
-}
-})();
+    return {
+        getDirection: function(context) {
+            var language = context ? context.language :
+                                     window.navigator.l10n.language;
+            if (language.indexOf('-') > -1) {
+                language = language.split('-')[0];
+            }
+            // http://www.w3.org/International/questions/qa-scripts
+            // Arabic, Hebrew, Farsi, Pashto, Urdu
+            return rtlList.indexOf(language) >= 0 ? 'rtl' : 'ltr';
+        },
+        gettext: get,
+        ngettext: nget,
+    };
+});

--- a/core/l10n_init.js
+++ b/core/l10n_init.js
@@ -1,0 +1,120 @@
+/*
+    A script that initializes l10n before include.js is loaded. Require this
+    before your main JS bundle.
+
+    Injects script tag for the locale file respective of the user's language.
+    The injected script tag is a JS file that sets window.navigator.l10n with
+    a locale obj populated with a script via .po files.
+    Should be minified in the build step and copied into the project's JS root.
+
+    This file is then served by Zamboni in mkt/commonplace, looking inside the
+    project's media root.
+*/
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else {
+        root.l10n_init = factory();
+    }
+}(this, function() {
+    var languages;
+    var bodyLangs = document.body.getAttribute('data-languages');
+    if (bodyLangs) {
+        languages = JSON.parse(bodyLangs);
+    } else {
+        languages = [
+            'bg', 'bn-BD', 'ca', 'cs', 'da', 'de', 'el', 'en-US', 'es', 'eu',
+            'fr', 'ga-IE', 'hr', 'hu', 'it', 'ja', 'ko', 'mk', 'nb-NO', 'nl',
+            'pa', 'pl', 'pt-BR', 'ro', 'ru', 'sk', 'sq', 'sr', 'sr-Latn', 'ta',
+            'tr', 'xh', 'zh-CN', 'zh-TW', 'zu', 'dbg'
+        ];
+    }
+    injectLocaleScript();
+
+    function injectLocaleScript(_testLocale) {
+        // Inject script to load locale file that populates w.navigator.1l0n.
+        var script = document.createElement('script');
+        script.src = getLocaleSrc(_testLocale || getLocale());
+        script.onerror = function() {
+            // If locale file not found, then fallback English (bug 1044195).
+            window.navigator.l10n = {
+                language: 'en-US'
+            };
+        };
+        document.body.appendChild(script);
+        return script;
+    }
+
+    function _transformLocale(locale) {
+        // If it's in the list of locales, return it.
+        if (languages.indexOf(locale) !== -1) {
+            return locale;
+        }
+
+        // If the prefix is in the list locales, return the prefix.
+        locale = locale.split('-')[0];
+        if (languages.indexOf(locale) !== -1) {
+            return locale;
+        }
+
+        // Expand locale with language suffix.
+        var langExpander = {
+            'en': 'en-US', 'ga': 'ga-IE', 'pt': 'pt-BR', 'sv': 'sv-SE',
+            'zh': 'zh-CN', 'sr': 'sr-Latn'
+        };
+        if (locale in langExpander) {
+            locale = langExpander[locale];
+            if (languages.indexOf(locale) !== -1) {
+                return locale;
+            }
+        }
+        return 'en-US';
+    }
+
+    function getLocale(_testLocale) {
+        // Returns the user's detected locale.
+        var qsLang = /[\?&]lang=([\w\-]+)/i.exec(window.location.search);
+        var locale = _transformLocale(_testLocale ||
+                                      (qsLang && qsLang[1]) ||
+                                      window.navigator.language ||
+                                      window.navigator.userLanguage);
+        if (locale === 'en-US') {
+            // Still pull English locale since translation doesn't necessarily
+            // always match gettext key (e.g., Feed brand).
+            // So don't return here yet; we may need the English locale file.
+            window.navigator.l10n = {
+                language: 'en-US'
+            };
+        }
+        return locale;
+    }
+
+    function getLocaleSrc(locale, _testDoc) {
+        var doc = _testDoc || window.document;
+
+        // Returns URL from where to load the appropriate JS locale file.
+        // For website, we need the CDN URL.
+        // If packaged, don't want the extra network request. Fortunately,
+        // data-media not set in packaged so it will load from the package.
+        var media_url = doc.body.getAttribute('data-media');
+
+        // If build ID, use for cachebusting. Else, in packaged app in don't
+        // care.
+        var buildId = doc.body.getAttribute('data-build-id-js');
+        var repo = doc.body.getAttribute('data-repo');
+        return [
+            media_url || '/media/',
+            repo ? repo + '/' : '',
+            'locales/' + locale + '.js',
+            buildId ? '?b=' + buildId : ''
+        ].join('');
+    }
+
+    return {
+        // Export mostly to unit test.
+        getLocale: getLocale,
+        getLocaleSrc: getLocaleSrc,
+        injectLocaleScript: injectLocaleScript,
+        languages: languages
+    };
+}));

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,7 +21,7 @@ module.exports = function(config) {
             'bower_components/underscore/underscore.js',
             {pattern: 'core/*.js', included: false},
             {pattern: 'core/views/*.js', included: false},
-            {pattern: 'tests/*.js', included: false},
+            {pattern: 'tests/**/*.js', included: false},
         ],
 
 

--- a/test-main.js
+++ b/test-main.js
@@ -43,23 +43,19 @@ Object.keys(window.__karma__.files).forEach(function(file) {
 });
 
 require.config({
-    // Karma serves files under /base, which is the basePath from your config file
+    // Karma serves files under /base, the basePath from your config file.
     baseUrl: '/base',
-
     paths: {
         jquery: 'bower_components/jquery/jquery',
         underscore: 'bower_components/underscore/underscore',
     },
-
     shim: {
         underscore: {
             exports: '_',
         },
     },
-
-    // dynamically load all test files
+    // Dynamically load all test files.
     deps: allTestFiles,
-
-    // we have to kickoff jasmine, as it is asynchronous
+    // Kick off jasmine since it is asynchronous.
     callback: window.__karma__.start
 });

--- a/tests/files/locales/es.js
+++ b/tests/files/locales/es.js
@@ -1,0 +1,10 @@
+// Test locale file.
+(function() {
+    if (!navigator.l10n) {
+        navigator.l10n = {};
+    }
+    navigator.l10n.language = 'es';
+    navigator.l10n.strings = {
+        'Test': {'body': 'Testo'}
+    };
+})();

--- a/tests/l10n.js
+++ b/tests/l10n.js
@@ -1,5 +1,4 @@
-define('tests/l10n', ['core/l10n'], function(eltenen) {
-
+define('tests/l10n', ['core/l10n'], function(l10n) {
     function MockNavigator(strings, pluralizer) {
         this.l10n = {
             strings: strings,
@@ -7,7 +6,7 @@ define('tests/l10n', ['core/l10n'], function(eltenen) {
         };
     }
 
-    var basic_context = new MockNavigator(
+    var mockContext = new MockNavigator(
         {foo: {body: 'bar'},
         formatted: {body: 'zip {zap}'},
         sing: {plurals: ['zero {n}', 'one {n}']},
@@ -15,119 +14,103 @@ define('tests/l10n', ['core/l10n'], function(eltenen) {
         function(n) {return n - 1 !== 0;}
     );
 
+    describe('l10n.getDirection', function() {
+        it('handles language directions', function() {
+            var context = {language: 'en-US'};
+            assert.equal(l10n.getDirection(context), 'ltr');
+            context.language = 'pt-BR';
+            assert.equal(l10n.getDirection(context), 'ltr');
+            context.language = 'ar';
+            assert.equal(l10n.getDirection(context), 'rtl');
+            context.language = 'ar-AR';
+            assert.equal(l10n.getDirection(context), 'rtl');
+            context.language = 'ar-POOP';
+            assert.equal(l10n.getDirection(context), 'rtl');
+        });
+    });
+
     describe('l10n.gettext', function() {
         it('translates', function() {
-            assert.equal(eltenen.gettext('foo', null, basic_context), 'bar');
+            assert.equal(l10n.gettext('foo', null, mockContext), 'bar');
         });
 
         it('has a fallback', function() {
-            assert.equal(eltenen.gettext('does not exist', null, basic_context), 'does not exist');
+            assert.equal(l10n.gettext('does not exist', null, mockContext),
+                         'does not exist');
         });
 
         it('accepts args', function() {
-            assert.equal(eltenen.gettext('formatted', {zap: 123}, basic_context), 'zip 123');
+            assert.equal(l10n.gettext('formatted', {zap: 123}, mockContext),
+                         'zip 123');
         });
 
         it('has fallback args', function() {
-            assert.equal(eltenen.gettext('does not {exist}', {exist: 123}, basic_context), 'does not 123');
+            assert.equal(l10n.gettext('does not {exist}', {exist: 123},
+                                      mockContext),
+                         'does not 123');
         });
     });
 
     describe('l10n.ngettext', function() {
         it('translates plurals', function() {
-            assert.equal(eltenen.ngettext('sing', 'plural', {n: 1}, basic_context), 'zero 1');
-            assert.equal(eltenen.ngettext('sing', 'plural', {n: 2}, basic_context), 'one 2');
+            assert.equal(l10n.ngettext('sing', 'plural', {n: 1},
+                                       mockContext),
+                         'zero 1');
+            assert.equal(l10n.ngettext('sing', 'plural', {n: 2},
+                                       mockContext),
+                         'one 2');
         });
 
         it('can have multiple pluralizations', function() {
-            var context = new MockNavigator(
+            var mockContext = new MockNavigator(
                 {sing: {plurals: ['0{n}', '1{n}', '2{n}', '3{n}']}},
                 function(n) {return n;}
             );
-            assert.equal(eltenen.ngettext('sing', 'plural', {n: 0}, context), '00');
-            assert.equal(eltenen.ngettext('sing', 'plural', {n: 1}, context), '11');
-            assert.equal(eltenen.ngettext('sing', 'plural', {n: 2}, context), '22');
-            assert.equal(eltenen.ngettext('sing', 'plural', {n: 3}, context), '33');
+            assert.equal(l10n.ngettext('sing', 'plural', {n: 0}, mockContext),
+                         '00');
+            assert.equal(l10n.ngettext('sing', 'plural', {n: 1}, mockContext),
+                         '11');
+            assert.equal(l10n.ngettext('sing', 'plural', {n: 2}, mockContext),
+                         '22');
+            assert.equal(l10n.ngettext('sing', 'plural', {n: 3}, mockContext),
+                         '33');
         });
 
         it('has a fallback', function() {
-            assert.equal(eltenen.ngettext('foo {n}', 'bar {n}', {n: 1}, basic_context), 'foo 1');
-            assert.equal(eltenen.ngettext('foo {n}', 'bar {n}', {n: 2}, basic_context), 'bar 2');
+            assert.equal(l10n.ngettext('foo {n}', 'bar {n}', {n: 1},
+                                       mockContext),
+                         'foo 1');
+            assert.equal(l10n.ngettext('foo {n}', 'bar {n}', {n: 2},
+                                       mockContext),
+                         'bar 2');
         });
 
         it('accepts args', function() {
-            assert.equal(eltenen.ngettext('sing2', 'sang2', {n: 1, asdf: 'bar'}, basic_context), 'zero 1 bar');
-            assert.equal(eltenen.ngettext('sing2', 'sang2', {n: 2, asdf: 'bar'}, basic_context), 'one 2 bar');
+            assert.equal(l10n.ngettext('sing2', 'sang2', {n: 1, asdf: 'bar'},
+                                       mockContext),
+                         'zero 1 bar');
+            assert.equal(l10n.ngettext('sing2', 'sang2', {n: 2, asdf: 'bar'},
+                                       mockContext),
+                         'one 2 bar');
         });
 
         it('has fallback args', function() {
-            assert.equal(eltenen.ngettext('foo {n} {asdf}', '', {n: 1, asdf: 'bar'}, basic_context),
-                'foo 1 bar');
-            assert.equal(eltenen.ngettext('', 'foo {n} {asdf}', {n: 2, asdf: 'bar'}, basic_context),
-                'foo 2 bar');
+            assert.equal(l10n.ngettext('foo {n} {asdf}', '',
+                                       {n: 1, asdf: 'bar'}, mockContext),
+                         'foo 1 bar');
+            assert.equal(l10n.ngettext('', 'foo {n} {asdf}',
+                                       {n: 2, asdf: 'bar'}, mockContext),
+                         'foo 2 bar');
         });
 
         it('errors without n argument', function(done, fail) {
             try {
-                console.error(eltenen.ngettext('singular', 'plural', {not_n: 1}, basic_context));
+                console.error(l10n.ngettext('singular', 'plural', {not_n: 1},
+                                            mockContext));
             } catch (e) {
                 return done();
             }
             fail();
-        });
-    });
-
-    describe('l10n', function() {
-        it('getDirection handles language directions', function() {
-            var context = {language: 'en-US'};
-            assert.equal(eltenen.getDirection(context), 'ltr');
-            context.language = 'pt-BR';
-            assert.equal(eltenen.getDirection(context), 'ltr');
-            context.language = 'ar';
-            assert.equal(eltenen.getDirection(context), 'rtl');
-            context.language = 'ar-AR';
-            assert.equal(eltenen.getDirection(context), 'rtl');
-            context.language = 'ar-POOP';
-            assert.equal(eltenen.getDirection(context), 'rtl');
-        });
-
-        it('getLocale helps find a locale', function() {
-            // Exact matches
-            assert.equal(eltenen.getLocale('en-US'), 'en-US');
-            // Shortened matches
-            assert.equal(eltenen.getLocale('de-DE'), 'de');
-            // Re-expanded matches
-            assert.equal(eltenen.getLocale('en-FOO'), 'en-US');
-            // Potato matches
-            assert.equal(eltenen.getLocale('potato-LOCALE'), 'en-US');
-        });
-
-        it('getLocaleSrc gives a URL/path to a locale file', function() {
-            // Mock document.body.getAttribute to test with different data-*
-            // attributes.
-            var doc = {
-                body: {
-                    getAttribute: function(attr) {
-                        return doc.body[attr];
-                    }
-                }
-            };
-            assert.equal(eltenen.getLocaleSrc('en-US', doc), '/media/locales/en-US.js');
-
-            doc.body['data-media'] = 'https://cdn.example.com/somewhere/';
-            assert.equal(eltenen.getLocaleSrc('en-US', doc),
-                'https://cdn.example.com/somewhere/locales/en-US.js');
-
-            doc.body['data-media'] = 'https://cdn.example.com/somewhere/';
-            doc.body['data-repo'] = 'bar';
-            assert.equal(eltenen.getLocaleSrc('en-US', doc),
-                'https://cdn.example.com/somewhere/bar/locales/en-US.js');
-
-            doc.body['data-media'] = 'https://cdn.example.com/somewhere/';
-            doc.body['data-repo'] = 'bar';
-            doc.body['data-build-id-js'] = '4815162342';
-            assert.equal(eltenen.getLocaleSrc('en-US', doc),
-                'https://cdn.example.com/somewhere/bar/locales/en-US.js?b=4815162342');
         });
     });
 });

--- a/tests/l10n_init.js
+++ b/tests/l10n_init.js
@@ -1,0 +1,114 @@
+define('tests/l10n_init', ['core/l10n_init'], function(l10n_init) {
+    function MockDoc() {
+        // Mock doc.body.getAttribute to test with different data-attrs.
+        var doc = {
+            body: {
+                getAttribute: function(attr) {
+                    return doc.body[attr];
+                }
+            }
+        };
+        return doc;
+    }
+
+    afterEach(function() {
+        window.navigator.l10n = undefined;
+    });
+
+    describe('l10n_init', function() {
+        it('injects script tag', function() {
+            l10n_init.injectLocaleScript('de');
+
+            var scripts = document.querySelectorAll('script');
+            var poScript = scripts[scripts.length - 1];
+            assert.ok(poScript.src.indexOf('/media/locales/de.js') !== -1);
+        });
+
+        it('injects script tag with test fixture file', function(done) {
+            // Test with an actual locale file (tests/locales/es.js).
+            document.body.setAttribute('data-media', '/base/tests/files/');
+            var script = l10n_init.injectLocaleScript('es');
+
+            var scripts = document.querySelectorAll('script');
+            var poScript = scripts[scripts.length - 1];
+            assert.ok(poScript.src.indexOf('/base/tests/files/locales/es.js') !== -1);
+
+            // When locale script loads, it should change the language.
+            script.onload = function() {
+                assert.equal(window.navigator.l10n.language, 'es');
+                done();
+            };
+        });
+
+        it('fall back to en-US if script error', function(done) {
+            var script = l10n_init.injectLocaleScript('de');
+
+            script.onerror = (function(existingOnerror) {
+                // Don't overwrite existing onerror. Call the code's onerror,
+                // then call our test's onerror.
+                if (existingOnerror) {
+                    existingOnerror.apply(this,arguments);
+                }
+                // When locale script 404s, it should fall back to en-US.
+                assert.equal(window.navigator.l10n.language, 'en-US');
+                done();
+            }(script.onerror));
+        });
+    });
+
+    describe('l10n_init.getLocale', function() {
+        it('gets exact match', function() {
+            // Exact matches
+            assert.equal(l10n_init.getLocale('en-US'), 'en-US');
+        });
+
+        it('gets shortened match', function() {
+            // Shortened matches
+            assert.equal(l10n_init.getLocale('de-DE'), 'de');
+        });
+
+        it('gets re-expanded match', function() {
+            // Re-expanded matches
+            assert.equal(l10n_init.getLocale('en-FOO'), 'en-US');
+        });
+
+        it('gets potato match', function() {
+            // Potato matches
+            assert.equal(l10n_init.getLocale('potato-LOCALE'), 'en-US');
+        });
+    });
+
+    describe('l10n_init.getLocaleSrc', function() {
+        it('gets path without data-media', function() {
+            var doc = MockDoc();
+            assert.equal(l10n_init.getLocaleSrc('en-US', doc),
+                         '/media/locales/en-US.js');
+        });
+
+        it('gets URL with data-media', function() {
+            var doc = MockDoc();
+            doc.body['data-media'] = 'https://cdn.example.com/somewhere/';
+            assert.equal(l10n_init.getLocaleSrc('en-US', doc),
+                         'https://cdn.example.com/somewhere/locales/en-US.js');
+        });
+
+        it('gets URL with data-media and data-repo', function() {
+            var doc = MockDoc();
+            doc.body['data-media'] = 'https://cdn.example.com/somewhere/';
+            doc.body['data-repo'] = 'bar';
+            assert.equal(
+                l10n_init.getLocaleSrc('en-US', doc),
+                'https://cdn.example.com/somewhere/bar/locales/en-US.js');
+        });
+
+        it('gets URL with data-media and data-repo and build ID', function() {
+            var doc = MockDoc();
+            doc.body['data-media'] = 'https://cdn.example.com/somewhere/';
+            doc.body['data-repo'] = 'bar';
+            doc.body['data-build-id-js'] = '4815162342';
+            assert.equal(
+                l10n_init.getLocaleSrc('en-US', doc),
+                'https://cdn.example.com/somewhere/bar/locales/en-US.js?b=4815162342');
+        });
+    });
+});


### PR DESCRIPTION
## Split l10n.js into l10n_init.js and l10n.js

**The problem:**

- We had duplicate code being requested twice via l10n.js.
- l10n.js was being served by Zamboni (unminified) and it is also a part of our include.js bundle.
- Probably due to developer oversight or lack of a build tool.
- The l10n.js served outside the bundle wasn't minified either which makes things worse.
- The two modules don't rely one another at all in terms of sharing code.

**How they will split:**

- l10n_init.js initializes l10n by injecting generated locale script tag. This runs before our include.js is loaded. It is responsible for setting window.navigator.l10n. [See Zamboni serve it before include.js](https://github.com/mozilla/zamboni/blob/master/mkt/commonplace/templates/commonplace/index.html#L58). 
- l10n.js simply exposes gettext, ngettext, and getDirection functions. 
- We will have the build tool minify and copy l10n_init.js into the project's JS root as l10n.js, just as Zamboni would expect.
- There's also a bunch of refactoring and formatting as usual.

## Fall back to en-US if no locale file

**The problem:**

- If the locale file hasn't been generated for the user's detected locale, it'll 404
- With no locale file, window.navigator.l10n stays undefined

**Solution:**

- Add an ```onerror``` that sets window.navigator.l10n.language to en-US.