### PR TITLE
v2.2.0 - Add packaged/iframed static properties to capabilities (bug 1117771)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "author": "Mozilla",
   "name": "marketplace-core-modules",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "ignore": [
     "bower.json",
     "LICENSE",

--- a/core/capabilities.js
+++ b/core/capabilities.js
@@ -44,6 +44,8 @@ define('core/capabilities', ['core/settings'], function(settings) {
         'debug': document.location.href.indexOf('dbg') >= 0,
         'debug_in_page': document.location.href.indexOf('dbginpage') >= 0,
         'console': window.console && typeof window.console.log === 'function',
+        'packaged': window.location.protocol === 'app:',
+        'iframed': window.top !== window.self,
         'replaceState': typeof history.replaceState === 'function',
         'chromeless': !!(window.locationbar && !window.locationbar.visible),
         'webApps': !!(navigator.mozApps && navigator.mozApps.install),


### PR DESCRIPTION
Following @ngokevin's suggestion in https://github.com/mozilla/fireplace/pull/900#discussion_r26507701

However, I don't know how to test it since it's a) a static property b) that depends on `window`. I'd like to avoid making a method since it doesn't need to be. Thoughts ?