### PR TITLE
Allow mocking of capabilities.{w,packagedW}ebApps

### DIFF
--- a/core/capabilities.js
+++ b/core/capabilities.js
@@ -48,8 +48,6 @@ define('core/capabilities', ['core/settings'], function(settings) {
         'iframed': window.top !== window.self,
         'replaceState': typeof history.replaceState === 'function',
         'chromeless': !!(window.locationbar && !window.locationbar.visible),
-        'webApps': !!(navigator.mozApps && navigator.mozApps.install),
-        'packagedWebApps': !!(navigator.mozApps && navigator.mozApps.installPackage),
         'userAgent': navigator.userAgent,
         'widescreen': function() { return safeMatchMedia('(min-width: 710px)'); },
         'firefoxAndroid': navigator.userAgent.indexOf('Firefox') !== -1 && navigator.userAgent.indexOf('Android') !== -1,
@@ -60,10 +58,36 @@ define('core/capabilities', ['core/settings'], function(settings) {
         'firefoxOS': navigator.mozApps && navigator.mozApps.installPackage &&
                      navigator.userAgent.indexOf('Android') === -1 &&
                      (navigator.userAgent.indexOf('Mobile') !== -1 || navigator.userAgent.indexOf('Tablet') !== -1),
-        'phantom': navigator.userAgent.match(/Phantom/),  // Don't use this if you can help it.
+        'phantom': navigator.userAgent.match(/(Phantom|Slimer)/),  // Don't use this if you can help it.
         'detectOS': detectOS,
         'os': detectOS(),
     };
+
+    function mockWebApps() {
+        return static_caps.phantom || settings.mockWebApps;
+    }
+
+    function supportsWebApps() {
+        return mockWebApps() ||
+            !!(navigator.mozApps && navigator.mozApps.install);
+    }
+
+    function supportsPackagedWebApps() {
+        return mockWebApps() ||
+            !!(navigator.mozApps && navigator.mozApps.installPackage);
+    }
+
+    // We want to make this dynamic for our UI tests but if
+    // Object.defineProperty does not exist this isn't a UI test and we don't
+    // need it to be dynamic.
+    if (Object.defineProperty) {
+        Object.defineProperty(static_caps, 'webApps', {get: supportsWebApps});
+        Object.defineProperty(static_caps, 'packagedWebApps',
+                              {get: supportsPackagedWebApps});
+    } else {
+        static_caps.webApps = supportsWebApps();
+        static_caps.packagedWebApps = supportsPackagedWebApps();
+    }
 
     static_caps.nativeFxA = function() {
         return (static_caps.firefoxOS && window.location.protocol === 'app:' &&

--- a/tests/capabilities.js
+++ b/tests/capabilities.js
@@ -1,6 +1,6 @@
 define('tests/capabilities',
-    ['core/capabilities'],
-    function(capabilities) {
+    ['core/capabilities', 'Squire'],
+    function(capabilities, Squire) {
 
     describe('capabilities.device_platform', function() {
         it('can be firefoxos', function() {
@@ -193,4 +193,157 @@ define('tests/capabilities',
         });
     });
 
+    describe('capabilities.webApps', function() {
+        var oldMozApps;
+
+        this.beforeEach(function() {
+            oldMozApps = navigator.mozApps;
+        });
+
+        this.afterEach(function() {
+            if (oldMozApps) {
+                navigator.mozApps = oldMozApps;
+            } else {
+                delete navigator.mozApps;
+            }
+        });
+
+        it('is true when mozApps.install is a function', function(done) {
+            navigator.mozApps = {install: function() {}};
+            new Squire().require(['core/capabilities'], function(caps) {
+                assert(caps.webApps, 'webApps should be on');
+                done();
+            });
+        });
+
+        it('is false when mozApps.install is undefined', function(done) {
+            navigator.mozApps = {};
+            new Squire().require(['core/capabilities'], function(caps) {
+                assert(!caps.webApps, 'webApps should be off');
+                done();
+            });
+        });
+
+        it('is false when mozApps is undefined', function(done) {
+            // It appears as though you can't delete this...
+            navigator.mozApps = undefined;
+            new Squire().require(['core/capabilities'], function(caps) {
+                assert(!caps.webApps, 'webApps should be off');
+                done();
+            });
+        });
+
+        it('is true when settings.mockWebApps is true', function(done) {
+            // It appears as though you can't delete this...
+            navigator.mozApps = undefined;
+            new Squire()
+            .mock('core/settings', {mockWebApps: true, switches: []})
+            .require(['core/capabilities'], function(caps) {
+                assert(caps.webApps, 'webApps should be on');
+                done();
+            });
+        });
+
+        it('changes when settings.mockWebApps changes', function(done) {
+            // It appears as though you can't delete this...
+            navigator.mozApps = undefined;
+            var settings = {mockWebApps: true, switches: []};
+            new Squire()
+            .mock('core/settings', settings)
+            .require(['core/capabilities'], function(caps) {
+                assert(caps.webApps, 'webApps should be on');
+                settings.mockWebApps = false;
+                assert(!caps.webApps, 'webApps should be off');
+                done();
+            });
+        });
+
+        it('works without Object.defineProperty', function(done) {
+            navigator.mozApps = {install: function() {}};
+            var oldDefineProperty = Object.defineProperty;
+            Object.defineProperty = undefined;
+            new Squire().require(['core/capabilities'], function(caps) {
+                assert(caps.webApps, 'webApps should be on');
+                Object.defineProperty = oldDefineProperty;
+                done();
+            });
+        });
+    });
+
+    describe('capabilities.packagedWebApps', function() {
+        var oldMozApps;
+
+        this.beforeEach(function() {
+            oldMozApps = navigator.mozApps;
+        });
+
+        this.afterEach(function() {
+            if (oldMozApps) {
+                navigator.mozApps = oldMozApps;
+            } else {
+                delete navigator.mozApps;
+            }
+        });
+
+        it('is true when mozApps.installPackage is a function', function(done) {
+            navigator.mozApps = {installPackage: function() {}};
+            new Squire().require(['core/capabilities'], function(caps) {
+                assert(caps.packagedWebApps, 'packagedWebApps should be on');
+                done();
+            });
+        });
+
+        it('is false when mozApps.installPackage is undefined', function(done) {
+            navigator.mozApps = {};
+            new Squire().require(['core/capabilities'], function(caps) {
+                assert(!caps.packagedWebApps, 'packagedWebApps should be off');
+                done();
+            });
+        });
+
+        it('is false when mozApps is undefined', function(done) {
+            // It appears as though you can't delete this...
+            navigator.mozApps = undefined;
+            new Squire().require(['core/capabilities'], function(caps) {
+                assert(!caps.packagedWebApps, 'packagedWebApps should be off');
+                done();
+            });
+        });
+
+        it('is true when settings.mockWebApps is true', function(done) {
+            // It appears as though you can't delete this...
+            navigator.mozApps = undefined;
+            new Squire()
+            .mock('core/settings', {mockWebApps: true, switches: []})
+            .require(['core/capabilities'], function(caps) {
+                assert(caps.packagedWebApps, 'packagedWebApps should be on');
+                done();
+            });
+        });
+
+        it('changes when settings.mockWebApps changes', function(done) {
+            // It appears as though you can't delete this...
+            navigator.mozApps = undefined;
+            var settings = {mockWebApps: true, switches: []};
+            new Squire()
+            .mock('core/settings', settings)
+            .require(['core/capabilities'], function(caps) {
+                assert(caps.packagedWebApps, 'packagedWebApps should be on');
+                settings.mockWebApps = false;
+                assert(!caps.packagedWebApps, 'packagedWebApps should be off');
+                done();
+            });
+        });
+
+        it('works without Object.defineProperty', function(done) {
+            navigator.mozApps = {installPackage: function() {}};
+            var oldDefineProperty = Object.defineProperty;
+            Object.defineProperty = undefined;
+            new Squire().require(['core/capabilities'], function(caps) {
+                assert(caps.packagedWebApps, 'packagedWebApps should be on');
+                Object.defineProperty = oldDefineProperty;
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
The slimerJS changes need this to support `capabilities.webApps` without mocking `navigator.mozApps` which seems to cause slimer to crash.