### PR TITLE
Use default locale on undefined param (#1138558)

### DIFF
--- a/core/l10n.js
+++ b/core/l10n.js
@@ -59,8 +59,14 @@ define('core/l10n',
 
     return {
         getDirection: function(context) {
-            var language = context ? context.language :
-                                     window.navigator.l10n.language;
+            // Try to get browser language, if undefined use default locale.
+            var language;
+            if (context) {
+                language = context.language;
+            } else {
+                language = window.navigator.l10n ? window.navigator.l10n.language :
+                                                  'en-US';
+            }
             if (language.indexOf('-') > -1) {
                 language = language.split('-')[0];
             }

--- a/core/l10n_init.js
+++ b/core/l10n_init.js
@@ -61,6 +61,8 @@ define('core/l10n_init',
     }
 
     function _transformLocale(locale) {
+        // Use default locale "en-US" if given locale is undefined.
+        locale = locale || 'en-US';
         // If it's in the list of locales, return it.
         if (languages.indexOf(locale) !== -1) {
             return locale;

--- a/tests/l10n_init.js
+++ b/tests/l10n_init.js
@@ -76,6 +76,11 @@ define('tests/l10n_init',
             // Potato matches
             assert.equal(l10n_init.getLocale('potato-LOCALE'), 'en-US');
         });
+
+        it('get undefined match', function() {
+            // Undefined matches
+            assert.equal(l10n_init.getLocale(undefined), 'en-US');
+        });
     });
 
     describe('l10n_init.getLocaleSrc', function() {


### PR DESCRIPTION
The locale in the _transformLocale method in the l10n_init module will be set to "en-US" when the given param is undefined. Param will be undefined when the user removes all available languages in his content->languages browser preferences.

~~Replaced window.navigator.l10n.language with window.navigator.language or if this property is still undefined with "en-US" in getDirection method in l10n module, e.g. http://www.w3.org/TR/html5/webappapis.html#navigatorlanguage.~~
