### PR TITLE
Set html[dir][lang] based on locale (bug 1152819)

### DIFF
--- a/core/l10n.js
+++ b/core/l10n.js
@@ -12,7 +12,7 @@
 define('core/l10n',
     ['core/format'],
     function(format) {
-    var RTL_LIST = ['ar', 'he', 'fa', 'ps', 'ur'];
+    var RTL_LIST = ['ar', 'he', 'fa', 'ps', 'rtl', 'ur'];
 
     function get(str, args, context) {
         context = context || navigator;

--- a/core/l10n_init.js
+++ b/core/l10n_init.js
@@ -24,8 +24,8 @@ define('core/l10n_init',
         languages = [
             'bg', 'bn-BD', 'ca', 'cs', 'da', 'de', 'el', 'en-US', 'es', 'eu',
             'fr', 'ga-IE', 'hr', 'hu', 'it', 'ja', 'ko', 'mk', 'nb-NO', 'nl',
-            'pa', 'pl', 'pt-BR', 'ro', 'ru', 'sk', 'sq', 'sr', 'sr-Latn', 'ta',
-            'tr', 'xh', 'zh-CN', 'zh-TW', 'zu', 'dbg'
+            'pa', 'pl', 'pt-BR', 'ro', 'rtl', 'ru', 'sk', 'sq', 'sr',
+            'sr-Latn', 'ta', 'tr', 'xh', 'zh-CN', 'zh-TW', 'zu', 'dbg'
         ];
     }
 
@@ -40,6 +40,8 @@ define('core/l10n_init',
         script.onload = function() {
             // Add body class for RTL.
             z.body.addClass('l10n--' + l10n.getDirection());
+            document.documentElement.setAttribute('dir', l10n.getDirection());
+            document.documentElement.setAttribute('lang', locale);
             l10nInitialized.resolve(locale, script);
         };
         script.onerror = function() {

--- a/tests/l10n_init.js
+++ b/tests/l10n_init.js
@@ -1,6 +1,6 @@
 define('tests/l10n_init',
-    ['core/l10n_init'],
-    function(l10n_init) {
+    ['core/l10n_init', 'Squire'],
+    function(l10n_init, Squire) {
 
     function MockDoc() {
         // Mock doc.body.getAttribute to test with different data-attrs.
@@ -109,6 +109,26 @@ define('tests/l10n_init',
             assert.equal(
                 l10n_init.getLocaleSrc('en-US', doc),
                 'https://cdn.example.com/somewhere/bar/locales/en-US.js?b=4815162342');
+        });
+    });
+
+    describe('l10n_init.languages', function() {
+        it('uses data-languages on <body>', function(done) {
+            document.body.setAttribute('data-languages', '["foo","bar"]');
+            new Squire().require(['core/l10n_init'], function(l10n_init) {
+                assert.deepEqual(l10n_init.languages, ['foo', 'bar']);
+                document.body.removeAttribute('data-languages');
+                done();
+            });
+        });
+
+        it('uses default languages without data-languages', function(done) {
+            document.body.removeAttribute('data-languages');
+            new Squire().require(['core/l10n_init'], function(l10n_init) {
+                // Don't look for specific languages, just that we have some.
+                assert(l10n_init.languages.length > 20);
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
Treat the `rtl` language as right-to-left, include it in the default list of languages.

I originally had some code to only add `rtl` to `l10n_init.languages` if you were on `localhost` or `127.0.0.1` but I think we always set `body[data-languages]` when zamboni is serving this so I just put it in the default.