### PR TITLE
Always specify FxA auth action (bug 1162010)

### DIFF
--- a/core/login.js
+++ b/core/login.js
@@ -109,10 +109,7 @@ define('core/login',
         if (capabilities.yulelogFxA()) {
             window.top.postMessage({type: 'fxa-request'}, packaged_origin);
         } else if (capabilities.fallbackFxA()) {
-            var fxa_url = settings.fxa_auth_url;
-            if (opt.register) {
-                fxa_url = utils.urlparams(fxa_url, {action: 'signup'});
-            }
+            var fxa_url = fxa_redirect_url({register: opt.register});
 
             if (opt.popupWindow) {
                 console.log('Changing location of supplied window to', fxa_url);
@@ -274,8 +271,15 @@ define('core/login',
         });
     }
 
+    function fxa_redirect_url(opt) {
+        opt = opt || {};
+        var action = opt.register ? 'signup' : 'signin';
+        return utils.urlparams(settings.fxa_auth_url, {action: action});
+    }
+
     return {
         login: startLogin,
+        fxa_redirect_url: fxa_redirect_url,
         get_fxa_auth_url: get_fxa_auth_url,
         handle_fxa_login: handle_fxa_login,
     };

--- a/tests/login.js
+++ b/tests/login.js
@@ -1,0 +1,20 @@
+define('tests/login',
+    ['core/login'],
+    function(login) {
+
+    describe('login.fxa_redirect_url', function() {
+        it('is the signin url when not registering', function() {
+            withSettings({fxa_auth_url: 'https://fxa.com/auth'}, function() {
+                assert.equal(login.fxa_redirect_url(),
+                             'https://fxa.com/auth?action=signin');
+            });
+        });
+
+        it('is the register url when registering', function() {
+            withSettings({fxa_auth_url: 'https://fxa.com/auth'}, function() {
+                assert.equal(login.fxa_redirect_url({register: true}),
+                             'https://fxa.com/auth?action=signup');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Without an action FxA now goes to sign in or register based on whether or not you've ever signed in. Since we have explicit sign in and register buttons we'd like to always go to sign in or register based on that choice.