### PR TITLE
fix nonexistent language property (bug 1208231)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "author": "Mozilla",
   "name": "marketplace-core-modules",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "ignore": [
     "bower.json",
     "LICENSE",

--- a/core/helpers.js
+++ b/core/helpers.js
@@ -116,6 +116,16 @@ define('core/helpers',
         logged_in: user.logged_in
     };
 
+    // Use '?lang=xx' param if present otherwise ask the browser.
+    function getLanguage() {
+        var params = utils.getVars();
+
+        if (params.lang) {
+            return params.lang;
+        }
+        return navigator.language ? navigator.language : 'en-US';
+    }
+
     // Functions provided in the default context.
     var helpers = {
         api: urls.api.url,
@@ -146,7 +156,7 @@ define('core/helpers',
         navigator: window.navigator,
         screen: window.screen,
         // TODO: Pull the default value from settings.
-        language: window.navigator.l10n ? window.navigator.l10n.language : 'en-US'
+        language: getLanguage()
     };
 
     // Put the helpers into the nunjucks global.


### PR DESCRIPTION
`window.l10n` exists in chrome but not FF, `window.language` seems to exist in both